### PR TITLE
Use Datadog's agent6-amazon-linux branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,7 @@
 [submodule "datadog"]
 	path = datadog
 	url = https://github.com/DataDog/chef-datadog.git
+	branch = agent6-amazon-linux
 [submodule "apt"]
 	path = apt
 	url = https://github.com/opscode-cookbooks/apt.git


### PR DESCRIPTION
Note: The [docs](https://github.com/DataDog/chef-datadog/tree/agent6-amazon-linux#cookbooks) say:

```
Note for Chef 11 users: please use these additional dependency version contraints for compatibility with Chef 11:

cookbook 'apt', '< 4.0'
cookbook 'chef_handler', '< 2.0'
cookbook 'windows', '< 2.0'
cookbook 'yum', '~> 3.0'
```
But I'm not sure where to specify these constraints.
